### PR TITLE
Fixed 404 error with no trailing backslash

### DIFF
--- a/wiki/webserver/NginxProxy.md
+++ b/wiki/webserver/NginxProxy.md
@@ -21,15 +21,15 @@ This is useful if you want to integrate your map in your website, or want to add
 - BlueMaps integrated webserver is running on port `8100`. *(Again, just replace `8100` with the actual port below)*
 
 ## BlueMap on a subdirectory of your website
-If you have a normal website hosted with NGINX and want your map on `/map/` (e.g `https://mydomain.com/map/`) then 
+If you have a normal website hosted with NGINX and want your map on `/map` (e.g `https://mydomain.com/map`) then 
 you can just add this to your NGINX configuration:
 ```nginx
 server {
   
   ...
 
-  location ~/map(.*)$ {
-    proxy_pass http://127.0.0.1:8100$1;
+  location /map/ {
+    proxy_pass http://127.0.0.1:8100/;
   }
 }
 ```


### PR DESCRIPTION
With an NGINX reverse-proxy on a sub-directory:
Instead of having to visit `https://mydomain.com/map/`, you can now also visit `https://mydomain.com/map` (no trailing backslash) without receiving a BlueMap 404 error.