### PR TITLE
Add Caddy to external web server docs

### DIFF
--- a/wiki/webserver/ExternalWebserversFile.md
+++ b/wiki/webserver/ExternalWebserversFile.md
@@ -129,3 +129,24 @@ ProxyPassMatch ^/(maps/[^/]*/live/.*) http://127.0.0.1:8100/$1
 > **Important:**<br>
 > The above config is **just an example** and not a complete config you can just copy&paste. You **will** need to adapt it to your setup!
 {: .info .important }
+
+## Caddy
+Newer versions of [Caddy](https://caddyserver.com/) have a `precompressed` option that's similar to Nginx's `gzip_static`. Unfortunately this [requires the "base" file](https://github.com/caddyserver/caddy/issues/5116) `.json` to also exist, but Bluemap only creates the "precompressed" files `.json.gz`.
+
+Here is the required config to serve the high-res `.json.gz` files correctly:
+```
+@json_gz {
+    header Accept-Encoding *gzip*
+    path *.json
+    file {
+        try_files {path}.gz
+    }
+}
+handle @json_gz {
+  header Content-Type application/json
+  header Content-Encoding gzip
+  rewrite {http.matchers.file.relative}
+}
+```
+
+The optional config (live-updating player markers, and avoiding 404s in the logs) are left as an exercise for the reader.

--- a/wiki/webserver/ExternalWebserversFile.md
+++ b/wiki/webserver/ExternalWebserversFile.md
@@ -142,7 +142,6 @@ http://your-domain {
   reverse_proxy /live/*  http://127.0.0.1:8100
 
   @JSONgz {
-    header Accept-Encoding *gzip*
     path *.json
     file {
         try_files {path}.gz

--- a/wiki/webserver/ExternalWebserversFile.md
+++ b/wiki/webserver/ExternalWebserversFile.md
@@ -134,19 +134,30 @@ ProxyPassMatch ^/(maps/[^/]*/live/.*) http://127.0.0.1:8100/$1
 Newer versions of [Caddy](https://caddyserver.com/) have a `precompressed` option that's similar to Nginx's `gzip_static`. Unfortunately this [requires the "base" file](https://github.com/caddyserver/caddy/issues/5116) `.json` to also exist, but Bluemap only creates the "precompressed" files `.json.gz`.
 
 Here is the required config to serve the high-res `.json.gz` files correctly:
-```
-@json_gz {
+```caddyfile
+http://your-domain {
+  root * /usr/share/caddy/
+  file_server
+
+  reverse_proxy /live/*  http://127.0.0.1:8100
+
+  @JSONgz {
     header Accept-Encoding *gzip*
     path *.json
     file {
         try_files {path}.gz
     }
-}
-handle @json_gz {
-  header Content-Type application/json
-  header Content-Encoding gzip
-  rewrite {http.matchers.file.relative}
+  }
+  handle @JSONgz {
+    rewrite {http.matchers.file.relative}
+    header Content-Type application/json
+    header Content-Encoding gzip
+  }
 }
 ```
 
-The optional config (live-updating player markers, and avoiding 404s in the logs) are left as an exercise for the reader.
+The optional config to avoid 404s in the logs is left as an exercise for the reader.
+
+> **Important:**<br>
+> The above config is **just an example** and not a complete config you can just copy&paste. You **will** need to adapt it to your setup!
+{: .info .important }


### PR DESCRIPTION
The [external web servers](https://bluemap.bluecolored.de/wiki/webserver/ExternalWebserversFile.html) page mentions Nginx and Apache. This PR adds Caddy, too.

The code is copied verbatim from [the Bluemap wiki](https://github.com/BlueMap-Minecraft/BlueMap/wiki/Directly-hosting-BlueMap-with-external-webservers#caddy).

(Which in turn is _probably_ adapted from [the Caddy forums](https://caddy.community/t/how-to-serve-pre-compressed-files-with-caddy-v2/8760/4).)

---

:wave: Hi! I would have found this useful when I was setting up Bluemap, so I figured I may as well PR it. But I'm not invested in this; if it isn't useful, feel free to close it :slightly_smiling_face: 