### PR TITLE
[fix] Caddy example live proxy not working

### DIFF
--- a/wiki/webserver/ExternalWebserversFile.md
+++ b/wiki/webserver/ExternalWebserversFile.md
@@ -139,7 +139,7 @@ http://your-domain {
   root * /usr/share/caddy/
   file_server
 
-  reverse_proxy /live/*  http://127.0.0.1:8100
+  reverse_proxy /maps/*/live/* http://127.0.0.1:8400
 
   @JSONgz {
     path *.json

--- a/wiki/webserver/ExternalWebserversFile.md
+++ b/wiki/webserver/ExternalWebserversFile.md
@@ -139,7 +139,7 @@ http://your-domain {
   root * /usr/share/caddy/
   file_server
 
-  reverse_proxy /maps/*/live/* http://127.0.0.1:8400
+  reverse_proxy /maps/*/live/* http://127.0.0.1:8100
 
   @JSONgz {
     path *.json


### PR DESCRIPTION
/live/ is no longer valid, we want /maps/\*/live/\* for the reverse proxy