### PR TITLE
Add Konquest to addons.conf

### DIFF
--- a/assets/addon_browser/addons.conf
+++ b/assets/addon_browser/addons.conf
@@ -520,4 +520,17 @@
 	  "github": "https://github.com/Arctic-Gaming-LLC/Heatmap"
     }
   }
+  {
+    name: "Konquest"
+    description: "Town claiming and capturing with global kingdoms, resident management and stats/titles. Displays territory regions using BlueMap."
+    author: "Rumsfield"
+    apiVersion: "2"
+    platforms: ["spigot", "paper", "purpur"]
+    links: {
+      "modrinth": "https://modrinth.com/plugin/konquest"
+      "spigotmc": "https://www.spigotmc.org/resources/konquest.92220/"
+      "curseforge": "https://www.curseforge.com/minecraft/bukkit-plugins/konquest"
+      "github": "https://github.com/Rumsfield/konquest"
+    }
+  }
 ]

--- a/assets/addon_browser/addons.conf
+++ b/assets/addon_browser/addons.conf
@@ -525,7 +525,7 @@
     description: "Town claiming and capturing with global kingdoms, resident management and stats/titles. Displays territory regions using BlueMap."
     author: "Rumsfield"
     apiVersion: "2"
-    platforms: ["spigot", "paper", "purpur"]
+    platforms: ["spigot", "paper"]
     links: {
       "modrinth": "https://modrinth.com/plugin/konquest"
       "spigotmc": "https://www.spigotmc.org/resources/konquest.92220/"


### PR DESCRIPTION
Adds Konquest plugin info to addons list. Konquest is a standalone land claiming plugin for Spigot that integrates natively with BlueMap.