### PR TITLE
Add BlueMap Floodgate Skins to addons.conf

### DIFF
--- a/assets/addon_browser/addons.conf
+++ b/assets/addon_browser/addons.conf
@@ -944,4 +944,14 @@
       "curseforge": "https://www.curseforge.com/minecraft/texture-packs/diagonal-suite-bluemap-compat"
     }
   }
+  {
+    name: "BlueMap Floodgate Skins"
+    description: "A native BlueMap addon that adds support for GeyserMC's Floodgate player skins."
+    author: "Toastberries"
+    apiVersion: "2"
+    platforms: ["bluemap"]
+    links: {
+      "github": "https://github.com/Toastberries/BlueMapFloodgateSkins"
+    }
+  }
 ]

--- a/assets/addon_browser/addons.conf
+++ b/assets/addon_browser/addons.conf
@@ -946,7 +946,7 @@
   }
   {
     name: "BlueMap Floodgate Skins"
-    description: "A native BlueMap addon that adds support for GeyserMC's Floodgate player skins."
+    description: "A native BlueMap addon that adds support for GeyserMCs Floodgate player skins."
     author: "Toastberries"
     apiVersion: "2"
     platforms: ["bluemap"]


### PR DESCRIPTION
Adds the [BlueMap Floodgate Skins](https://github.com/Toastberries/BlueMapFloodgateSkins) native addon to the addons list.