### PR TITLE
Added Modrinth link to "Diagonal Suite Bluemap Compat"

### DIFF
--- a/assets/addon_browser/addons.conf
+++ b/assets/addon_browser/addons.conf
@@ -941,6 +941,7 @@
     apiVersion: ""
     platforms: ["resourcepack"]
     links: {
+      "modrinth": "https://modrinth.com/resourcepack/diagonal-suite-bluemap-compat"
       "curseforge": "https://www.curseforge.com/minecraft/texture-packs/diagonal-suite-bluemap-compat"
     }
   }


### PR DESCRIPTION
Added Modrinth link to "Diagonal Suite Bluemap Compat"
Should have waited for it to be approved on both platforms before doing the original PR, sorry bout that.