### PR TITLE
Adding HexMapping to `addons.conf`

### DIFF
--- a/assets/addon_browser/addons.conf
+++ b/assets/addon_browser/addons.conf
@@ -959,7 +959,7 @@
     name: "HexMapping"
     description: "Hexcasting x Web Map Mods"
     author: "TechTastic"
-    apiVersion: ""
+    apiVersion: "2"
     platforms: ["forge", "fabric", "quilt"]
     links: {
       "curseforge": "https://www.curseforge.com/minecraft/mc-mods/hexmapping"

--- a/assets/addon_browser/addons.conf
+++ b/assets/addon_browser/addons.conf
@@ -965,5 +965,6 @@
       "curseforge": "https://www.curseforge.com/minecraft/mc-mods/hexmapping"
       "github": "https://github.com/TechTastic/HexMapping"
       "other": "https://techtastic.github.io/HexMapping/v/latest/main/en_us/"
+    }
   }
 ]

--- a/assets/addon_browser/addons.conf
+++ b/assets/addon_browser/addons.conf
@@ -955,4 +955,15 @@
       "github": "https://github.com/Toastberries/BlueMapFloodgateSkins"
     }
   }
+  {
+    name: "HexMapping"
+    description: "Hexcasting x Web Map Mods"
+    author: "TechTastic"
+    apiVersion: ""
+    platforms: ["forge", "fabric", "quilt"]
+    links: {
+      "curseforge": "https://www.curseforge.com/minecraft/mc-mods/hexmapping"
+      "github": "https://github.com/TechTastic/HexMapping"
+      "other": "https://techtastic.github.io/HexMapping/v/latest/main/en_us/"
+  }
 ]


### PR DESCRIPTION
[HexMapping](https://www.curseforge.com/minecraft/mc-mods/hexmapping) is a 1.20.1 [Hexcasting](https://www.curseforge.com/minecraft/mc-mods/hexcasting) addon that adds new patterns and iotas for casters ingame to create new markers on Bluemap, Dynmap, Pl3xmap, and Squaremap!

It also has interop with [Hexical](https://modrinth.com/mod/hexical), another Hexcasting addon, for its dye iotas and new mesh entity

Available on CurseForge and Modrinth when they stop dragging their feet