### PR TITLE
Update ExternalWebserversFile.md

### DIFF
--- a/wiki/webserver/ExternalWebserversFile.md
+++ b/wiki/webserver/ExternalWebserversFile.md
@@ -96,7 +96,6 @@ Don't forget to restart apache2 after installing any missing module via `a2enmod
 ```apache
 DocumentRoot /var/www/
 <Directory /var/www/>
-  allow from all
   Options FollowSymLinks
   Require all granted
   SetEnv no-gzip


### PR DESCRIPTION
"Require All Granted" is the way apache24 (latest apache) would prefer you allow access [https://httpd.apache.org/docs/2.4/howto/access.html#:~:text=The%20Allow%2C%20Deny%2C%20and%20Order%20directives%2C%20provided%20by%20mod_access_compat%2C%20are%20deprecated%20and%20will%20go%20away%20in%20a%20future%20version.%20You%20should%20avoid%20using%20them%2C%20and%20avoid%20outdated%20tutorials%20recommending%20their%20use.](https://httpd.apache.org/docs/2.4/howto/access.html)

trying to start a fresh Apache24 install with this will get the error  "_Invalid command 'allow', perhaps misspelled or defined by a module not included in the server configuration_"
You'd have to enable _mod_access_compat_ for backwards compatibility to make it work right with this, and per the apache website this is not recommended.

Tested on my Apache build and it works by simply removing this code.