### PR TITLE
Add BlueMapPortalMarkers to the addon browser

### DIFF
--- a/assets/addon_browser/addons.conf
+++ b/assets/addon_browser/addons.conf
@@ -1447,4 +1447,17 @@
       "github": "https://github.com/Uiniel/BlueMap-Create-Resource-Pack"
     }
   }
+  {
+    name: "BlueMapPortalMarkers"
+    description: "Adds a toggleable Nether Portals layer to BlueMap, auto-updating as portals are lit, discovered, and broken, with predicted Overworld↔Nether links."
+    author: "BunkPitch"
+    apiVersion: "2"
+    platforms: ["paper"]
+    links: {
+      "modrinth": "https://modrinth.com/plugin/bluemapportalmarkers"
+      "curseforge": "https://www.curseforge.com/minecraft/bukkit-plugins/bluemapportalmarkers"
+      "hangar": "https://hangar.papermc.io/BunkPitch/BlueMapPortalMarkers"
+      "github": "https://github.com/maldis018/BlueMapPortalMarkers"
+    }
+  }
 ]


### PR DESCRIPTION
Adds **BlueMapPortalMarkers** to the 3rd-party addon browser.

A Paper plugin that adds a toggleable **Nether Portals** marker layer to BlueMap, kept in sync as portals are lit, discovered, and broken, and persisted across restarts. When linking is enabled, each popup also shows the predicted Overworld↔Nether counterpart with a deep-link to it.

- **Platform:** `paper`
- **BlueMapAPI:** v2
- **Links:** Modrinth, CurseForge, Hangar, GitHub

All linked pages are live.