### PR TITLE
Add BlueMap Player Models

### DIFF
--- a/assets/addon_browser/addons.conf
+++ b/assets/addon_browser/addons.conf
@@ -1470,4 +1470,14 @@
       "github": "https://github.com/Chicken/BlueMap-Linear/"
     }
   }
+  {
+    name: "BlueMap Player Models"
+    description: "Adds animated 3D player models, loaded entities, equipment, inventories, and logout positions to BlueMap."
+    author: "DecoderCoder"
+    apiVersion: "2"
+    platforms: ["forge"]
+    links: {
+      "github": "https://github.com/DecoderCoder/bluemap-player-models"
+    }
+  }
 ]


### PR DESCRIPTION
## What changed

- Add BlueMap Player Models to the third-party addon browser.
- Link its public GitHub repository.

## Why

BlueMap Player Models is a Forge 1.20.1 addon that uses BlueMapAPI v2 to add animated player models, loaded entities, equipment, inventories, and logout positions.

## Impact

BlueMap users can discover the addon from the official third-party support list.

## Checks

- Parsed `addons.conf` with the site's bundled HOCON parser (143 entries).
- Verified the linked GitHub repository is public.
- Built the addon with Gradle and passed its Java and JavaScript self-checks.
