### PR TITLE
Lazy server guide: use connect vs read timeout for paused servers

### DIFF
--- a/community/BluemapLazyServer.md
+++ b/community/BluemapLazyServer.md
@@ -96,7 +96,7 @@ server {
     # Proxy all requests for live data to the integrated webserver.
     # Fall back to @server-offline if it can't be contacted.
     location ~* ^/maps/[^/]*/live/ {
-      proxy_read_timeout 2s;  # required if lazymc pauses the server instead of shutting it down
+      proxy_connect_timeout 2s;  # required if lazymc pauses the server instead of shutting it down
       error_page 502 504 = @server-offline;
       proxy_pass http://127.0.0.1:8100;  # the default port for the integrated webserver, adapt to your setup
     }


### PR DESCRIPTION
Using `proxy_read_timeout` causes the `[...]/live/sse` endpoint to time out if events aren't sent fast enough.

Using `proxy_connect_timeout` instead fixes this since the timeout is based on the initial connection instead of how often data is received from it.